### PR TITLE
Added VIA instructions to Firmware Flashing docs

### DIFF
--- a/firmware/firmware_flashing.md
+++ b/firmware/firmware_flashing.md
@@ -1,17 +1,26 @@
-# Firmware Flashing
+# QMK Flashing Instructions
+Follow these instructions to flash your Pro Micro or Bit-C microcontroller:
+1. Download the firmware for your device. If using [VIA](https://caniusevia.com) to configure, download the VIA version:
+    * For Nibble - [Default](https://github.com/nullbitsco/nibble/releases/download/v1.3/nullbitsco_nibble_default.hex) | [VIA](https://github.com/nullbitsco/nibble/releases/download/v1.3/nullbitsco_nibble_via.hex)
+    * For Tidbit - [Default](https://github.com/nullbitsco/tidbit/releases/download/v1.4/nullbitsco_tidbit_default.hex)  |  [VIA](https://github.com/nullbitsco/tidbit/releases/download/v1.4/nullbitsco_tidbit_via.hex)
+    * For Scramble - [Default](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_scramble_default.hex)
+2. Download and install [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases). If on Windows, also install device drivers when prompted. 
+4. Connect your Pro-Micro MCU in DFU Mode. If using a new Bit-C, it will be in DFU mode by default (LED will glow white).
+6. Open QMK Toolbox and select the firmware file you downloaded earlier.
+7. Click flash and wait for it to complete.
+8. Disconnect and reconnect the Pro-Micro or Bit-C. On the Bit-C, the LED light will stop glowing indicating that the board has loaded the firmware. 
 
-## Building and flashing QMK firmware 
+# Setting up VIA
+1. Flash VIA compatible firmware for your device, as described above. 
+2. Download and install [VIA](https://caniusevia.com).
+3. Download the VIA keymap file for your device - [Nibble](https://github.com/nullbitsco/nibble/blob/master/keymaps/via/nibble.json) | [Tidbit](https://github.com/nullbitsco/tidbit/blob/master/keymaps/via/tidbit.json).
+4. Connect your device and open VIA.
+5. If your device is not detected, go to Settings > Enable "Show Design Tab".
+6. Go to the Design tab.
+7. Click "Load Draft Definition" and upload the VIA keymap file you downloaded in step 3.
+8. Go to the Configure tab. Your device should now be detected and ready to configure. 
 
-# Contents
-[Helpful Links](#helpful_links)  
-[NIBBLE](#nibble)  
-[TIDBIT](#tidbit)  
-[SCRAMBLE](#scramble)  
-[Proton-C conversion](#proton_c)  
-[Flashing Instructions and Firmware Binaries](#releases)  
-
-
-# <a name="helpful_links"></a> Helpful links
+## <a name="helpful_links"></a> Helpful links
 Check out these awesome resources before diving into firmware customizations.
 * [QMK Tutorial: QMK Toolbox (Flashing Firmware On Your Keyboard)](https://youtu.be/fuBJbdCFF0Q)
 * [QMK Tutorial: How to get VIA on your board](https://youtu.be/lyvf7Yp1z5g)
@@ -20,22 +29,4 @@ Check out these awesome resources before diving into firmware customizations.
 ## [TODO] <a name="proton_c"></a> Proton-C conversion
 https://github.com/jaygreco/qmk_firmware/tree/proton_c_conversion
 
-## [TODO] <a name="nibble"></a> NIBBLE
-
-## [TODO] <a name="tidbit"></a> TIDBIT
-
-## [TODO] <a name="scramble"></a> SCRAMBLE
-
-## <a name="releases"></a> Flashing Instructions and Firmware Binaries
-
-Follow these instructions to flash your Pro Micro or Bit-C microcontroller:
-1. Download the firmware for your device:
-    * [NIBBLE default firmware](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_nibble_default.hex)
-    * [TIDBIT default firmware](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_tidbit_default.hex)
-    * [SCRAMBLE default firmware](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_scramble_default.hex)
-
-2. Download [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases).
-3. Connect your Pro-Micro in DFU mode. If using a new Bit-C, it will be in DFU mode already as indicated by the glowing white LED.
-4. Open QMK Toolbox and select the firmware file.
-5. Click flash and wait for it to complete.
-6. Disconnect and reconnect the Pro-Micro or Bit-C. On the Bit-C, the LED light will stop glowing indicating that the board has loaded the firmware. 
+## [TODO] Firmware Building Instructions

--- a/firmware/firmware_flashing.md
+++ b/firmware/firmware_flashing.md
@@ -1,26 +1,17 @@
-# QMK Flashing Instructions
-Follow these instructions to flash your Pro Micro or Bit-C microcontroller:
-1. Download the firmware for your device. If using [VIA](https://caniusevia.com) to configure, download the VIA version:
-    * For Nibble - [Default](https://github.com/nullbitsco/nibble/releases/download/v1.3/nullbitsco_nibble_default.hex) | [VIA](https://github.com/nullbitsco/nibble/releases/download/v1.3/nullbitsco_nibble_via.hex)
-    * For Tidbit - [Default](https://github.com/nullbitsco/tidbit/releases/download/v1.4/nullbitsco_tidbit_default.hex)  |  [VIA](https://github.com/nullbitsco/tidbit/releases/download/v1.4/nullbitsco_tidbit_via.hex)
-    * For Scramble - [Default](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_scramble_default.hex)
-2. Download and install [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases). If on Windows, also install device drivers when prompted. 
-4. Connect your Pro-Micro MCU in DFU Mode. If using a new Bit-C, it will be in DFU mode by default (LED will glow white).
-6. Open QMK Toolbox and select the firmware file you downloaded earlier.
-7. Click flash and wait for it to complete.
-8. Disconnect and reconnect the Pro-Micro or Bit-C. On the Bit-C, the LED light will stop glowing indicating that the board has loaded the firmware. 
+# Firmware Flashing
 
-# Setting up VIA
-1. Flash VIA compatible firmware for your device, as described above. 
-2. Download and install [VIA](https://caniusevia.com).
-3. Download the VIA keymap file for your device - [Nibble](https://github.com/nullbitsco/nibble/blob/master/keymaps/via/nibble.json) | [Tidbit](https://github.com/nullbitsco/tidbit/blob/master/keymaps/via/tidbit.json).
-4. Connect your device and open VIA.
-5. If your device is not detected, go to Settings > Enable "Show Design Tab".
-6. Go to the Design tab.
-7. Click "Load Draft Definition" and upload the VIA keymap file you downloaded in step 3.
-8. Go to the Configure tab. Your device should now be detected and ready to configure. 
+## Building and flashing QMK firmware 
 
-## <a name="helpful_links"></a> Helpful links
+# Contents
+[Helpful Links](#helpful_links)  
+[NIBBLE](#nibble)  
+[TIDBIT](#tidbit)  
+[SCRAMBLE](#scramble)  
+[Proton-C conversion](#proton_c)  
+[Flashing Instructions and Firmware Binaries](#releases)  
+
+
+# <a name="helpful_links"></a> Helpful links
 Check out these awesome resources before diving into firmware customizations.
 * [QMK Tutorial: QMK Toolbox (Flashing Firmware On Your Keyboard)](https://youtu.be/fuBJbdCFF0Q)
 * [QMK Tutorial: How to get VIA on your board](https://youtu.be/lyvf7Yp1z5g)
@@ -29,4 +20,22 @@ Check out these awesome resources before diving into firmware customizations.
 ## [TODO] <a name="proton_c"></a> Proton-C conversion
 https://github.com/jaygreco/qmk_firmware/tree/proton_c_conversion
 
-## [TODO] Firmware Building Instructions
+## [TODO] <a name="nibble"></a> NIBBLE
+
+## [TODO] <a name="tidbit"></a> TIDBIT
+
+## [TODO] <a name="scramble"></a> SCRAMBLE
+
+## <a name="releases"></a> Flashing Instructions and Firmware Binaries
+
+Follow these instructions to flash your Pro Micro or Bit-C microcontroller:
+1. Download the firmware for your device:
+    * [NIBBLE default firmware](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_nibble_default.hex)
+    * [TIDBIT default firmware](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_tidbit_default.hex)
+    * [SCRAMBLE default firmware](https://github.com/nullbitsco/docs/raw/main/firmware/default_firmware/nullbitsco_scramble_default.hex)
+
+2. Download [QMK Toolbox](https://github.com/qmk/qmk_toolbox/releases).
+3. Connect your Pro-Micro in DFU mode. If using a new Bit-C, it will be in DFU mode already as indicated by the glowing white LED.
+4. Open QMK Toolbox and select the firmware file.
+5. Click flash and wait for it to complete.
+6. Disconnect and reconnect the Pro-Micro or Bit-C. On the Bit-C, the LED light will stop glowing indicating that the board has loaded the firmware. 

--- a/tidbit/oled_install_guide.md
+++ b/tidbit/oled_install_guide.md
@@ -1,0 +1,12 @@
+# SSD1306 OLED Install Guide
+
+If you purchased the Nullbits OLED, or a SSD1306 OLED, follow this guide to install it on your device.
+
+## For Tidbit
+1. Solder 4 header pins with their short ends in the Tidbit PCB.
+2. [OPTIONAL] If building with plate, install hotswap / mill-max sockets and install plate before proceeding.
+3. Insert the OLED on the header pins such that the far end rests on the USB-C port. Use tape to hold it in place and ensure it is horizontal.
+4. Solder the OLED in place. Be careful not to damage the display while soldering.
+5. Flash the [OLED keymap firmware](https://github.com/nullbitsco/tidbit/releases/download/v1.5/nullbitsco_tidbit_oled.hex) for the Tidbit (flashing instructions can be found [here](https://github.com/nullbitsco/docs/blob/main/firmware/firmware_flashing.md)).
+
+If installed correctly, the OLED will show the Nullbits logo when plugged in.

--- a/tidbit/oled_install_guide.md
+++ b/tidbit/oled_install_guide.md
@@ -3,10 +3,14 @@
 If you purchased the Nullbits OLED, or a SSD1306 OLED, follow this guide to install it on your device.
 
 ## For Tidbit
-1. Solder 4 header pins with their short ends in the Tidbit PCB.
-2. [OPTIONAL] If building with plate, install hotswap / mill-max sockets and install plate before proceeding.
-3. Insert the OLED on the header pins such that the far end rests on the USB-C port. Use tape to hold it in place and ensure it is horizontal.
-4. Solder the OLED in place. Be careful not to damage the display while soldering.
+1. Solder 4 header pins with their short ends into the marked sockets on the Tidbit PCB.<br>
+_[TODO: Add picture of header pins placed in PCB with a highlight rectangle drawn around them.]_
+2. [OPTIONAL] If building with plate, install hotswap / mill-max sockets and install plate before proceeding.<br>
+_[TODO: Add picture of plate and switches installed in PCB and OLED header pins sticking out through plate.]_
+3. Insert the OLED on the header pins such that the far end rests on the USB-C port. Use tape to hold it in place and ensure it is horizontal.<br>
+_[TODO: Insert picture of OLED position after insert through header pins.]_
+4. Solder the OLED. Be careful not to damage the display while soldering.
 5. Flash the [OLED keymap firmware](https://github.com/nullbitsco/tidbit/releases/download/v1.5/nullbitsco_tidbit_oled.hex) for the Tidbit (flashing instructions can be found [here](https://github.com/nullbitsco/docs/blob/main/firmware/firmware_flashing.md)).
 
-If installed correctly, the OLED will show the Nullbits logo when plugged in.
+If installed correctly, the OLED will show the Nullbits logo when plugged in.<br>
+_[TODO: Insert picture of OLED displaying Nullbits logo]_

--- a/tidbit/oled_install_guide.md
+++ b/tidbit/oled_install_guide.md
@@ -3,14 +3,12 @@
 If you purchased the Nullbits OLED, or a SSD1306 OLED, follow this guide to install it on your device.
 
 ## For Tidbit
-1. Solder 4 header pins with their short ends into the marked sockets on the Tidbit PCB.<br>
-_[TODO: Add picture of header pins placed in PCB with a highlight rectangle drawn around them.]_
-2. [OPTIONAL] If building with plate, install hotswap / mill-max sockets and install plate before proceeding.<br>
-_[TODO: Add picture of plate and switches installed in PCB and OLED header pins sticking out through plate.]_
-3. Insert the OLED on the header pins such that the far end rests on the USB-C port. Use tape to hold it in place and ensure it is horizontal.<br>
-_[TODO: Insert picture of OLED position after insert through header pins.]_
-4. Solder the OLED. Be careful not to damage the display while soldering.
-5. Flash the [OLED keymap firmware](https://github.com/nullbitsco/tidbit/releases/download/v1.5/nullbitsco_tidbit_oled.hex) for the Tidbit (flashing instructions can be found [here](https://github.com/nullbitsco/docs/blob/main/firmware/firmware_flashing.md)).
 
-If installed correctly, the OLED will show the Nullbits logo when plugged in.<br>
-_[TODO: Insert picture of OLED displaying Nullbits logo]_
+| Instructions  |  |
+| ------------- | ------------- |
+| 1. Solder 4 header pins with their short ends into the marked sockets on the Tidbit PCB. | ![20210702_112859 2](https://user-images.githubusercontent.com/6137765/125806537-60477246-6bb8-4462-ab28-4ea64b4c72f5.jpg) |
+| 2. [OPTIONAL] If building with plate, install hotswap / mill-max sockets and install plate before proceeding. | _[TODO: Add picture of plate and switches installed in PCB and OLED header pins sticking out through plate.]_ |
+| 3. Insert the OLED on the header pins such that the far end rests on the USB-C port. Use tape to hold it in place and ensure it is horizontal. | _[TODO: Add picture of plate and switches installed in PCB and OLED header pins sticking out through plate.]_ |
+| 4. Solder the OLED. Be careful not to damage the display while soldering. | |
+| 5. Flash the [OLED keymap firmware](https://github.com/nullbitsco/tidbit/releases/download/v1.5/nullbitsco_tidbit_oled.hex) for the Tidbit (flashing instructions can be found [here](https://github.com/nullbitsco/docs/blob/main/firmware/firmware_flashing.md)). | |
+| 6. If installed correctly, the OLED will show the Nullbits/Tidbit logo when plugged in. | ![tidbit-oled-working](https://user-images.githubusercontent.com/6137765/125805368-d5f325c5-ef39-4e8b-bd2d-b73182ff3ae6.jpg) |


### PR DESCRIPTION
This PR adds instructions for setting up VIA for nullbits devices. It also cleans up the page for an easier reading experience.